### PR TITLE
DND time for notifications and fixes

### DIFF
--- a/subscribers/tasks.py
+++ b/subscribers/tasks.py
@@ -26,7 +26,11 @@ def refresh_sms_count():
 @celery_app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(
-        config.SNIFFING_INTERVAL_SECONDS, check_available_slots.s()
+        crontab(
+            hour="5-22",
+            minute="*/5",
+        ),
+        check_available_slots.s(),
     )
 
     sender.add_periodic_task(

--- a/vaccination_slot_notifier/settings.py
+++ b/vaccination_slot_notifier/settings.py
@@ -181,7 +181,6 @@ PHONENUMBER_DEFAULT_REGION = "IN"
 # Constance Settings
 CONSTANCE_CONFIG = {
     "SMS_SERVICE_ACTIVE": (False, "Whether SMS service is active or not"),
-    "SNIFFING_INTERVAL_SECONDS": (300, "Seconds between each sniffer iteration"),
     "MAIL_COOLDOWN_SECONDS": (1800, "Seconds before a new mail is sent to a user."),
     "MAX_DAILY_SMS_COUNT": (5, "Maximum number of sms in a day to a user."),
 }


### PR DESCRIPTION
Removed celery periodic conf from django.constance settings. To be added in a future version with dj-celery
Closes #12 